### PR TITLE
fix config.h includes

### DIFF
--- a/libiconv/localcharset.c
+++ b/libiconv/localcharset.c
@@ -19,7 +19,7 @@
 
 /* Written by Bruno Haible <bruno@clisp.org>.  */
 
-#include <config.h>
+#include "config.h"
 
 /* Specification.  */
 #include "localcharset.h"

--- a/libiconv/relocatable.c
+++ b/libiconv/relocatable.c
@@ -26,7 +26,7 @@
 #endif
 
 #define _GL_USE_STDLIB_ALLOC 1
-#include <config.h>
+#include "config.h"
 
 /* Specification.  */
 #include "relocatable.h"


### PR DESCRIPTION
`#include <config.h>` usually does not compile (I tried Visual Studio 2015 RC), #include "config.h" always do.

Big thanks for the repository!
Wanted to use it in my public https://github.com/alex85k/winbuilds buildscripts collection.
